### PR TITLE
RDKBACCL-388 : WPS support in Banana Pi R4

### DIFF
--- a/rdk-wps-monitor/Makefile
+++ b/rdk-wps-monitor/Makefile
@@ -1,5 +1,5 @@
 ##########################################################################
-# If not stated otherwise in this file or this component's Licenses.txt
+# If not stated otherwise in this file or this component's LICENSE 
 # file the following copyright and licenses apply:
 #
 # Copyright 2025 RDK Management

--- a/rdk-wps-monitor/include/button_callback.h
+++ b/rdk-wps-monitor/include/button_callback.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/include/device_monitor.h
+++ b/rdk-wps-monitor/include/device_monitor.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/include/netlink_monitor.h
+++ b/rdk-wps-monitor/include/netlink_monitor.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/include/utils.h
+++ b/rdk-wps-monitor/include/utils.h
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/source/button_callback.c
+++ b/rdk-wps-monitor/source/button_callback.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/source/device_monitor.c
+++ b/rdk-wps-monitor/source/device_monitor.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/source/main.c
+++ b/rdk-wps-monitor/source/main.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/source/netlink_monitor.c
+++ b/rdk-wps-monitor/source/netlink_monitor.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management

--- a/rdk-wps-monitor/source/utils.c
+++ b/rdk-wps-monitor/source/utils.c
@@ -1,5 +1,5 @@
 /*
- * If not stated otherwise in this file or this component's Licenses.txt file the
+ * If not stated otherwise in this file or this component's LICENSE file the
  * following copyright and licenses apply:
  *
  * Copyright 2025 RDK Management


### PR DESCRIPTION
Reason for change: To activate the functionality of WPS PBC as an utility from Hardware
Test procedure: 2GHz and 5GHz wps clients has to be connected from WPS PBC Hardware Key press
Risks: Low