### PR TITLE
RDKBACCL-863 : brlan0 interface MAC ID is changing upon every device reboot

### DIFF
--- a/rdkb-bpi-mac/source/main.cpp
+++ b/rdkb-bpi-mac/source/main.cpp
@@ -38,7 +38,8 @@ int main() {
         {"lan3", 0x01, 0x03},
         {"wifi0", 0x02, 0x00},
         {"wifi1", 0x02, 0x01},
-        {"wifi2", 0x02, 0x02}
+        {"wifi2", 0x02, 0x02},
+        {"brlan0", 0x02, 0x00}
     };
     
     // Read serial number


### PR DESCRIPTION
brlan0 interface MAC ID is changing upon every device reboot , added changes in the existing mac address code to generate  mac address for brlan0 based upon the serial number which is unique same as for other interfaces like wifi0 etc