### PR TITLE
RDKBACCL-1004 : Need to add logic of wifi constant mac for EM builds

### DIFF
--- a/rdkb-bpi-mac/source/main.cpp
+++ b/rdkb-bpi-mac/source/main.cpp
@@ -39,7 +39,13 @@ int main() {
         {"wifi0", 0x02, 0x00},
         {"wifi1", 0x02, 0x01},
         {"wifi2", 0x02, 0x02},
-        {"brlan0", 0x02, 0x00}
+#if defined(_EM_BUILD_)
+        {"wifi1.1", 0x02, 0x03},
+#if defined(_EM_EXT_BUILD_)
+        {"wifi0.1", 0x02, 0x04},
+#endif
+#endif	
+        {"brlan0", 0x03, 0x00}
     };
     
     // Read serial number


### PR DESCRIPTION
Reason for change: Added required interface list to support ctrl and ext
Test procedure: Tested with daisy chain
Risks: None