### PR TITLE
RDKBACCL-870: Integrating "gw-lan-refresh" utility for banana pi

### DIFF
--- a/gw-lan-refresh/Readme
+++ b/gw-lan-refresh/Readme
@@ -1,0 +1,42 @@
+Description:
+This code implements an application to refresh the lan clients connected ports for updating the DHCP configuration.
+
+Core Functionality:
+The program is to refresh all the eth ports except the port which is associated with WAN for BPI R4 device. As part of the refresh it will restart wifi clients using "X_CISCO_COM_KickAssocDevices" DM.
+
+Sample Output:
+root@Filogic-GW:/rdklogs/logs# gw_lan_refresh
+[  619.265690] brlan0: port 1(lan1) entered disabled state
+[  619.275415] mt7530 mdio-bus:1f lan2: Link is Down
+[  619.281093] brlan0: port 2(lan2) entered disabled state
+[  619.291225] brlan0: port 3(lan3) entered disabled state
+gw_lan_refresh
+refresh_external_switch(): setting admin status down for port 1
+refresh_external_switch(): setting admin status down for port 2
+refresh_external_switch(): setting admin status down for port 3
+[  623.300639] mt7530 mdio-bus:1f lan1: configuring for phy/gmii link mode
+[  623.307505] 8021q: adding VLAN 0 to HW filter on device lan1
+[  623.317077] mt7530 mdio-bus:1f lan2: configuring for phy/gmii link mode
+[  623.324052] 8021q: adding VLAN 0 to HW filter on device lan2
+[  623.333377] mt7530 mdio-bus:1f lan3: configuring for phy/gmii link mode
+[  623.340286] 8021q: adding VLAN 0 to HW filter on device lan3
+root@Filogic-GW:/rdklogs/logs# [  623.530492] wifi1: moving STA e0:1f:88:f9:ac:36 to state 3
+[  623.556269] wifi1: Rx BA session stop requested for e0:1f:88:f9:ac:36 tid 0 recipient reason: 36
+[  623.565837] wifi1: Rx BA session stop requested for e0:1f:88:f9:ac:36 tid 1 recipient reason: 36
+[  623.575016] wifi1: Rx BA session stop requested for e0:1f:88:f9:ac:36 tid 7 recipient reason: 36
+[  623.584323] wifi1: Tx BA session stop requested for e0:1f:88:f9:ac:36 tid 0
+[  623.620043] wifi1: Tx BA session stop requested for e0:1f:88:f9:ac:36 tid 1
+[  623.644235] wifi1: Tx BA session stop requested for e0:1f:88:f9:ac:36 tid 4
+[  623.672113] wifi1: Tx BA session stop requested for e0:1f:88:f9:ac:36 tid 7
+[  623.752069] mt7996e 0000:01:00.0: mt7996_set_key: keyidx=0, link_bitmap=0x1 (STA e0:1f:88:f9:ac:36)
+[  623.761882] wifi1: moving STA e0:1f:88:f9:ac:36 to state 2
+[  623.767478] wifi1: moving STA e0:1f:88:f9:ac:36 to state 1
+[  623.773033] mt7996e 0000:01:00.0: mt7996_mac_sta_remove_links: removed_links=0x1
+[  623.780450] mt7996e 0000:01:00.0: mt7996_mcu_add_sta: link=0, wcid=1, newly=0, conn_state=0
+[  623.790781] wifi1: Removed STA e0:1f:88:f9:ac:36
+[  623.795875] wifi1: Destroyed STA e0:1f:88:f9:ac:36
+refresh_external_switch(): setting admin status up for port 1
+refresh_external_switch(): setting admin status up for port 2
+refresh_external_switch(): setting admin status up for port 3
+Successfully set Device.WiFi.AccessPoint.1.X_CISCO_COM_KickAssocDevices
+Successfully set Device.WiFi.AccessPoint.2.X_CISCO_COM_KickAssocDevices

--- a/gw-lan-refresh/source/gw_lan_refresh.c
+++ b/gw-lan-refresh/source/gw_lan_refresh.c
@@ -1,0 +1,124 @@
+/*
+ * If not stated otherwise in this file or this component's LICENSE file the
+ * following copyright and licenses apply:
+ *
+ * Copyright 2025 RDK Management
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+/**
+ * @file gw_lan_refresh.c
+ * @brief Main program entry for the Gateway Lan Refresh daemon
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+#include <rbus.h>
+#include <pthread.h>
+
+#include "ccsp/ccsp_hal_ethsw.h"
+
+#define CONSOLE_LOG_FILE "/rdklogs/logs/Consolelog.txt.0"
+
+#define DBG_PRINT(fmt ...)     {\
+    FILE     *fp        = NULL;\
+    fp = fopen ( CONSOLE_LOG_FILE, "a+");\
+    if (fp)\
+    {\
+        fprintf(fp,fmt);\
+        fclose(fp);\
+    }\
+}\
+
+
+#define SLEEP_TIME 4
+
+pthread_mutex_t gw_lan_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+void refresh_external_switch()
+{
+    CCSP_HAL_ETHSW_PORT port;
+    INT max_phy_eth_ports = 0;
+
+    /* Total 3 LAN ports*/
+    max_phy_eth_ports = CCSP_HAL_ETHSW_EthPort3;
+
+    for (port = CCSP_HAL_ETHSW_EthPort1; port <= max_phy_eth_ports; port++)
+    {
+        // Disable the port
+        DBG_PRINT("%s(): setting admin status down for port %d\n", __FUNCTION__, port);
+        CcspHalEthSwSetPortAdminStatus(port, CCSP_HAL_ETHSW_AdminDown);
+    }
+
+    sleep(SLEEP_TIME);
+
+    for (port = CCSP_HAL_ETHSW_EthPort1; port <= max_phy_eth_ports; port++)
+    {
+        // Enable the port
+        DBG_PRINT("%s(): setting admin status up for port %d\n", __FUNCTION__, port);
+        CcspHalEthSwSetPortAdminStatus(port, CCSP_HAL_ETHSW_AdminUp);
+    }
+}
+
+void set_wifi_refresh_dm(rbusHandle_t handle, const char* param) {
+    pthread_mutex_lock(&gw_lan_mutex);
+
+    rbusError_t err = rbus_setBoolean(handle, param, true);
+    if (err != RBUS_ERROR_SUCCESS) {
+        DBG_PRINT("Failed to set %s: %d\n", param, err);
+    } else {
+        DBG_PRINT("Successfully set %s\n", param);
+    }
+
+    pthread_mutex_unlock(&gw_lan_mutex);
+}
+
+void refresh_wifi()
+{
+    rbusHandle_t handle;
+    rbusError_t err;
+    err = rbus_open(&handle, "gw_lan_refresh");
+    if (err != RBUS_ERROR_SUCCESS) {
+        DBG_PRINT("Failed to initialize RBus: %d\n", err);
+    }
+    /* dis-associate connected wifi clients */
+    set_wifi_refresh_dm(handle,"Device.WiFi.AccessPoint.1.X_CISCO_COM_KickAssocDevices");
+    set_wifi_refresh_dm(handle,"Device.WiFi.AccessPoint.2.X_CISCO_COM_KickAssocDevices");
+
+    rbus_close(handle);
+}
+
+int main(int argc, char **argv)
+{
+    if (argc == 2) {
+        if (strncmp (argv[1], "ethsw", strlen ("ethsw")) == 0) {
+            DBG_PRINT ("[%s] calling to update ethsw setting \n",argv[0]);
+            refresh_external_switch();
+        }else if (strncmp (argv[1], "wifi", strlen ("wifi")) == 0) {
+            DBG_PRINT ("[%s] calling to update wifi setting \n",argv[0]);
+            refresh_wifi();
+        }
+        else {
+            
+        }
+    }else {
+        DBG_PRINT("gw_lan_refresh \n");
+        refresh_external_switch();
+        refresh_wifi();
+    }
+    return 0;
+}


### PR DESCRIPTION
Reason for change:
    Integrating gw_lan_refresh utility for banana pi.
Test Procedure:
    Execute gw_lan_refresh command from the device console and verify that lan ports are refreshing are not.
Risks: None