### PR TITLE
RDKBACCL-1144: LAN IP change via tr181 parameter is not getting reflected in brlan0

### DIFF
--- a/gw-lan-refresh/source/gw_lan_refresh.c
+++ b/gw-lan-refresh/source/gw_lan_refresh.c
@@ -55,9 +55,9 @@ void refresh_external_switch()
     INT max_phy_eth_ports = 0;
 
     /* Total 3 LAN ports*/
-    max_phy_eth_ports = CCSP_HAL_ETHSW_EthPort3;
+    max_phy_eth_ports = CCSP_HAL_ETHSW_EthPort4;
 
-    for (port = CCSP_HAL_ETHSW_EthPort1; port <= max_phy_eth_ports; port++)
+    for (port = CCSP_HAL_ETHSW_EthPort2; port <= max_phy_eth_ports; port++)
     {
         // Disable the port
         DBG_PRINT("%s(): setting admin status down for port %d\n", __FUNCTION__, port);
@@ -66,7 +66,7 @@ void refresh_external_switch()
 
     sleep(SLEEP_TIME);
 
-    for (port = CCSP_HAL_ETHSW_EthPort1; port <= max_phy_eth_ports; port++)
+    for (port = CCSP_HAL_ETHSW_EthPort2; port <= max_phy_eth_ports; port++)
     {
         // Enable the port
         DBG_PRINT("%s(): setting admin status up for port %d\n", __FUNCTION__, port);


### PR DESCRIPTION
Reason for change:
    Due to change in ethernet lan interfaces, modified gw_lan_refresh code accordingly.
Test Procedure:
    Execute gw_lan_refresh from the console and verify three lan ports are refreshed or not.
Risks: None