### PR TITLE
RDKBWIFI-388: Add support for onboarding extender using WPS mechanism in RDK-B

### DIFF
--- a/rdk-wps-monitor/source/button_callback.c
+++ b/rdk-wps-monitor/source/button_callback.c
@@ -70,13 +70,19 @@ void default_button_callback(const char *device, int button_code, int value) {
         printf("Failed to initialize RBus: %d\n", err);
     }
 
-    // Set WPS Push Button for Access Point 1
-    log_message(LOG_INFO, "WPS button pressed on device %s - triggering WPS action for 2G", device);
-    set_wps_push_button(handle, "Device.WiFi.AccessPoint.1.WPS.X_CISCO_COM_ActivatePushButton");
-
-    // Set WPS Push Button for Access Point 2
-    log_message(LOG_INFO, "WPS button pressed on device %s - triggering WPS action for 5G", device);
-    set_wps_push_button(handle, "Device.WiFi.AccessPoint.2.WPS.X_CISCO_COM_ActivatePushButton");
+#ifdef CONFIG_EXTENDER
+     // Set WPS Push Button for Station Interface
+     log_message(LOG_INFO, "WPS button pressed on device %s - triggering WPS action for station", device);
+     set_wps_push_button(handle, "Device.WiFi.AccessPoint.16.WPS.X_CISCO_COM_ActivatePushButton");
+#else
+     // Set WPS Push Button for Access Point 1
+     log_message(LOG_INFO, "WPS button pressed on device %s - triggering WPS action for 2G", device);
+     set_wps_push_button(handle, "Device.WiFi.AccessPoint.1.WPS.X_CISCO_COM_ActivatePushButton");
+ 
+     // Set WPS Push Button for Access Point 2
+     log_message(LOG_INFO, "WPS button pressed on device %s - triggering WPS action for 5G", device);
+     set_wps_push_button(handle, "Device.WiFi.AccessPoint.2.WPS.X_CISCO_COM_ActivatePushButton");
+#endif
     sleep(WPS_DELAY);
 
     // Close RBus


### PR DESCRIPTION
On extender builds (CONFIG_EXTENDER), trigger WPS PBC on the station AccessPoint.16 interface instead of FH AP.1/AP.2.